### PR TITLE
feat: add support for windows

### DIFF
--- a/src/__tests__/fs.ts
+++ b/src/__tests__/fs.ts
@@ -118,7 +118,7 @@ test('should list files', async () => {
   const files = await list('**/*', testSpaceDir);
 
   const cleanedFiles = files.map((file) =>
-    file.replace(path.resolve(testSpaceDir), '.'),
+    file.replace(path.resolve(testSpaceDir), '.').replace(/\\/g, '/'),
   );
 
   expect(cleanedFiles).toEqual([
@@ -136,7 +136,7 @@ test('should list files matching pattern', async () => {
   const files = await list('**/testFile*', testSpaceDir);
 
   const cleanedFiles = files.map((file) =>
-    file.replace(path.resolve(testSpaceDir), '.'),
+    file.replace(path.resolve(testSpaceDir), '.').replace(/\\/g, '/'),
   );
 
   expect(cleanedFiles).toEqual(['./testFile1.txt', './testFile2.txt']);
@@ -150,7 +150,7 @@ test('should list files matching extensions', async () => {
   const files = await list('**/*', testSpaceDir, { extensions: ['txt', 'js'] });
 
   const cleanedFiles = files.map((file) =>
-    file.replace(path.resolve(testSpaceDir), '.'),
+    file.replace(path.resolve(testSpaceDir), '.').replace(/\\/g, '/'),
   );
 
   expect(cleanedFiles).toEqual(['./testFile1.txt', './testFile2.js']);

--- a/src/__tests__/help.ts
+++ b/src/__tests__/help.ts
@@ -5,9 +5,17 @@ const execAsync = promisify(exec);
 
 test('npx unimported --help', async () => {
   // note about `./` path: jest executes the tests from the root directory
-  const { stdout, stderr } = await execAsync(
-    `LC_ALL='en' ts-node src/index.ts --help`,
-  );
+  let execResults;
+  if (process.platform === 'win32') {
+    // Windows won't understand LC_ALL='en'
+    execResults = await execAsync(
+      `set LC_All='en' && ts-node src/index.ts --help`,
+    );
+  } else {
+    execResults = await execAsync(`LC_ALL='en' ts-node src/index.ts --help`);
+  }
+
+  const { stdout, stderr } = execResults;
 
   expect(stderr).toBe('');
   expect(stdout.trim()).toMatchInlineSnapshot(`

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,10 +137,16 @@ export async function main(args: CliArguments): Promise<void> {
       ignore: context.ignore,
     });
 
+    const normalizedFiles = files.map((path) => path.replace(/\\/g, '/'));
+
     spinner.text = 'process results';
     spinner.stop();
 
-    const result = await processResults(files, traverseResult, context);
+    const result = await processResults(
+      normalizedFiles,
+      traverseResult,
+      context,
+    );
 
     if (args.update) {
       await updateAllowLists(result, context);

--- a/src/process.ts
+++ b/src/process.ts
@@ -31,13 +31,13 @@ export async function processResults(
 
   const unused = Object.keys(context.dependencies).filter(
     (x) =>
-      !traverseResult.modules.has(x.replace(/\\/g, '/')) &&
+      !traverseResult.modules.has(x) &&
       !context.peerDependencies[x] &&
       !ignoreUnusedIdx[x],
   );
 
   const unimported = files
-    .filter((x) => !traverseResult.files.has(x.replace(/\\/g, '/')))
+    .filter((x) => !traverseResult.files.has(x))
     .map((x) => x.substr(context.cwd.length + 1))
     .filter((x) => !ignoreUnimportedIdx[x]);
 

--- a/src/process.ts
+++ b/src/process.ts
@@ -31,13 +31,13 @@ export async function processResults(
 
   const unused = Object.keys(context.dependencies).filter(
     (x) =>
-      !traverseResult.modules.has(x) &&
+      !traverseResult.modules.has(x.replace(/\\/g, '/')) &&
       !context.peerDependencies[x] &&
       !ignoreUnusedIdx[x],
   );
 
   const unimported = files
-    .filter((x) => !traverseResult.files.has(x))
+    .filter((x) => !traverseResult.files.has(x.replace(/\\/g, '/')))
     .map((x) => x.substr(context.cwd.length + 1))
     .filter((x) => !ignoreUnimportedIdx[x]);
 


### PR DESCRIPTION
I just wanted to use this on a project under Windows today, and discovered that it wasn't finding any matches (so all files were being returned as not imported).

I did some debugging in my `node_modules` folder and discovered that the comparison (`.has(x)`) ends up comparing a path that looks like: `C:\\Repositories\\file.tsx` with `C:/Repositories/files.tsx`, so I changed the lines to `.has(x.replace(/\\/g, '/'))` and started seeing results like I was expecting.

I'm not sure what you'd prefer - running the replace inline during the `.has()`, or if we want to do it in index.ts on line 135 (where you resolve the glob `'**/*'`). As such, feel free to give me some feedback as to how you'd like it done.

I haven't validated if there are any other Windows issues yet.