### PR TITLE
feat: support loading path aliases from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ You can also add an optional `moduleDirectory` option to your configuration file
 }
 ```
 
+**Custom aliases**
+If you wish to use aliases to import your modules & these can't be imported
+directly (e.g. `tsconfig.json` in the case of Typescript), there is an option
+`aliases` to provide the correct path mapping:
+
+```json
+{
+  "aliases": {
+    "@components/*": ["./components", "./components/*"],
+    ...
+  }
+}
+```
+
+_Note:_ you may wish to also add the `rootDir` option to specify the base path to
+start looking for the aliases from:
+
+```json
+{
+  "rootDir": "./src"
+}
+```
+
 ## Report
 
 The report will look something like [below](#example). When a particular check didn't have any positive results, it's section will be excluded from the output.

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -141,6 +141,35 @@ cases(
       stdout: /1 unimported files.*bar.js/s,
     },
     {
+      name: 'Invalid json',
+      files: [
+        {
+          name: '.unimportedrc.json',
+          content: '{ "entry": ["index.js"} }',
+        },
+      ],
+      exitCode: 1,
+      stdout: '',
+    },
+    {
+      name: 'next project',
+      files: [
+        {
+          name: '.next/test.json',
+          content: '{ "entry": ["index.js"] }',
+        },
+        {
+          name: 'package.json',
+          content:
+            '{ "main": "index.js", "dependencies": { "@test/dependency": "1.0.0" } }',
+        },
+        { name: 'index.js', content: `import foo from './foo';` },
+        { name: 'foo.js', content: '' },
+      ],
+      exitCode: 1,
+      stdout: /1 unused dependencies.*@test\/dependency/s,
+    },
+    {
       name: 'should identify unused dependencies',
       files: [
         {
@@ -233,6 +262,21 @@ export default promise
         {
           name: 'tsconfig.json',
           content: '{ "compilerOptions": { "paths": { "@root": ["."] } } }',
+        },
+      ],
+      exitCode: 1,
+      stdout: /1 unimported files.*bar.ts/s,
+    },
+    {
+      name: 'should identify config alias imports',
+      files: [
+        { name: 'package.json', content: '{ "main": "index.ts" }' },
+        { name: 'index.ts', content: `import foo from '@root/foo';` },
+        { name: 'foo.ts', content: '' },
+        { name: 'bar.ts', content: '' },
+        {
+          name: '.unimportedrc.json',
+          content: '{ "aliases": { "@root": ["."] }, "rootDir": "/" }',
         },
       ],
       exitCode: 1,

--- a/src/__tests__/help.ts
+++ b/src/__tests__/help.ts
@@ -4,6 +4,10 @@ import { exec } from 'child_process';
 const execAsync = promisify(exec);
 
 test('npx unimported --help', async () => {
+  // the async call below can take longer than the default 5 seconds,
+  // so increase as necessary.
+  jest.setTimeout(10000);
+
   // note about `./` path: jest executes the tests from the root directory
   let execResults;
   if (process.platform === 'win32') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { Context } from './index';
 import glob from 'glob';
 import { promisify } from 'util';
 import { ensureArray } from './ensureArray';
+import { MapLike } from 'typescript';
 
 const globAsync = promisify(glob);
 
@@ -16,6 +17,8 @@ export interface UnimportedConfig {
   ignoreUnimported: string[];
   ignoreUnused: string[];
   moduleDirectory?: string[];
+  aliases?: MapLike<string[]>;
+  rootDir?: string;
 }
 
 export async function expandGlob(


### PR DESCRIPTION
- Added ability to add `aliases` to config
- Updated documentation
- Updated tests

Using aliases outside of Tsconfig requires (possibly) a additional `rootDir` to be set in the config to allow matching from the base path.

To pass the 90% threshold for code coverage, I have also added a couple of minor additional tests - checking for invalid config json & importing in next.js

This may also fix #20.

closes #26 