### PR TITLE
Create cache for eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/typescript-estree": "^4.15.2",
     "chalk": "^4.1.0",
     "eslint": "^7.20.0",
+    "file-entry-cache": "^6.0.1",
     "flow-remove-types": "^2.145.0",
     "glob": "^7.1.6",
     "ora": "^5.3.0",
@@ -54,6 +55,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
+    "@types/file-entry-cache": "^5.0.1",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.20",
     "@types/jest-in-case": "^1.0.3",

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -6,12 +6,29 @@ import simpleGit from 'simple-git';
 import { main, CliArguments } from '..';
 import { purgeCache } from '../cache';
 
+import FileEntryCache from 'file-entry-cache';
+
 const mkdir = util.promisify(fs.mkdir);
 const rmdir = util.promisify(fs.rmdir);
 const writeFile = util.promisify(fs.writeFile);
 const readFile = util.promisify(fs.readFile);
 
 jest.mock('simple-git');
+
+jest.mock('file-entry-cache', () => {
+  const actual = jest.requireActual('file-entry-cache');
+  let mockedCache: FileEntryCache.FileEntryCache;
+  return {
+    get mockedCache() {
+      return mockedCache;
+    },
+    create(...args) {
+      mockedCache = actual.create(...args);
+      mockedCache.removeEntry = jest.fn(mockedCache.removeEntry);
+      return mockedCache;
+    },
+  };
+});
 
 async function exec(
   testProjectDir: string,
@@ -126,8 +143,8 @@ cases(
         ignoreUntracked: scenario.ignoreUntracked,
       });
 
-      expect(stdout).toMatch(scenario.stdout);
-      expect(stderr).toMatch('');
+      expect(stdout).toMatch(scenario.stdout || '');
+      expect(stderr).toMatch(scenario.stderr || '');
       expect(exitCode).toBe(scenario.exitCode);
 
       // Exec again to test cache primed case
@@ -146,8 +163,8 @@ cases(
         ignoreUntracked: scenario.ignoreUntracked,
       }));
 
-      expect(stdout).toMatch(scenario.stdout);
-      expect(stderr).toMatch('');
+      expect(stdout).toMatch(scenario.stdout || '');
+      expect(stderr).toMatch(scenario.stderr || '');
       expect(exitCode).toBe(scenario.exitCode);
     } finally {
       await rmdir(testProjectDir, { recursive: true });
@@ -390,7 +407,7 @@ export default promise
         { name: 'index.js', content: `not valid` },
       ],
       exitCode: 1,
-      stdout: /Failed parsing.*\/index.js/s,
+      stderr: /Failed parsing.*\/index.js/s,
     },
     {
       name: 'should ignore non import/require paths',
@@ -644,3 +661,97 @@ cases(
     },
   ],
 );
+
+describe('cache', () => {
+  const files = [
+    {
+      name: 'package.json',
+      content:
+        '{ "main": "index.js", "dependencies": { "@test/dependency": "1.0.0" } }',
+    },
+    {
+      name: 'index.js',
+      content: `
+import foo from './foo';
+import bar from './bar';
+`,
+    },
+    { name: 'foo.js', content: '' },
+    { name: 'bar.js', content: 'import test from "@test/dependency"' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should invalidate the cache on parse error', async () => {
+    const testProjectDir = await createProject(files);
+
+    try {
+      let { stdout, stderr, exitCode } = await exec(testProjectDir);
+
+      expect(stdout).toMatch(/There don't seem to be any unimported files./);
+      expect(stderr).toMatch('');
+      expect(exitCode).toBe(0);
+
+      fs.unlinkSync(path.join(testProjectDir, 'bar.js'));
+
+      ({ stdout, stderr, exitCode } = await exec(testProjectDir, {}));
+
+      expect(stdout).toMatch(/1 unresolved imports.*.\/bar/s);
+      expect(stderr).toMatch('');
+      expect(exitCode).toBe(1);
+
+      expect(
+        (FileEntryCache as any).mockedCache.removeEntry.mock.calls.map(
+          ([filePath]) => path.basename(filePath),
+        ),
+      ).toMatchInlineSnapshot(`
+        Array [
+          "bar.js",
+          "bar.js",
+          "index.js",
+        ]
+      `);
+    } finally {
+      await rmdir(testProjectDir, { recursive: true });
+    }
+  });
+
+  it('should recover from extension rename', async () => {
+    const testProjectDir = await createProject(files);
+
+    try {
+      let { stdout, stderr, exitCode } = await exec(testProjectDir);
+
+      expect(stdout).toMatch(/There don't seem to be any unimported files./);
+      expect(stderr).toMatch('');
+      expect(exitCode).toBe(0);
+
+      fs.renameSync(
+        path.join(testProjectDir, 'bar.js'),
+        path.join(testProjectDir, 'bar.ts'),
+      );
+
+      ({ stdout, stderr, exitCode } = await exec(testProjectDir, {}));
+
+      expect(stdout).toMatch(/There don't seem to be any unimported files./);
+      expect(stderr).toMatch('');
+      expect(exitCode).toBe(0);
+
+      expect(
+        (FileEntryCache as any).mockedCache.removeEntry.mock.calls.map(
+          ([filePath]) => path.basename(filePath),
+        ),
+      ).toMatchInlineSnapshot(`
+        Array [
+          "bar.js",
+          "bar.js",
+          "index.js",
+        ]
+      `);
+    } finally {
+      await rmdir(testProjectDir, { recursive: true });
+    }
+  });
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,31 @@
+import fileEntryCache, { FileDescriptor } from 'file-entry-cache';
+
+type CacheMeta<T> = FileDescriptor['meta'] & { data: T };
+
+const cache = fileEntryCache.create('unimported', './node_modules/.cache/');
+
+export async function resolveEntry<T>(
+  path: string,
+  generator: () => Promise<T>,
+): Promise<T> {
+  const cacheEntry = cache.getFileDescriptor(path);
+  const meta: CacheMeta<T> = cacheEntry.meta as CacheMeta<T>;
+
+  if (cacheEntry.changed || !meta?.data) {
+    meta.data = await generator();
+  }
+
+  return meta.data;
+}
+
+export function invalidateEntry(path: string): void {
+  cache.removeEntry(path);
+}
+
+export function storeCache(): void {
+  cache.reconcile();
+}
+
+export function purgeCache(): void {
+  cache.deleteCacheFile();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   updateAllowLists,
   writeConfig,
 } from './config';
+import { storeCache } from './cache';
 
 export interface TsConfig {
   compilerOptions: CompilerOptions;
@@ -160,6 +161,8 @@ export async function main(args: CliArguments): Promise<void> {
       traverseResult,
       context,
     );
+
+    storeCache();
 
     if (args.update) {
       await updateAllowLists(result, context);

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -14,6 +14,7 @@ import type {
 import resolve from 'resolve';
 import chalk from 'chalk';
 import removeFlowTypes from 'flow-remove-types';
+import { invalidateEntry, resolveEntry } from './cache';
 
 export interface FileStats {
   path: string;
@@ -251,9 +252,11 @@ export async function traverse(
 
   let parseResult;
   try {
-    parseResult = await parse(path, context);
+    parseResult = await resolveEntry(path, () => parse(path, context));
     result.files.set(path, parseResult);
   } catch (e) {
+    invalidateEntry(path);
+
     console.log(chalk.redBright(`\nFailed parsing ${path}`));
     console.log(e);
     process.exit(1);


### PR DESCRIPTION
This utilizes the same caching mechanism as eslint to reduce eval time. Dropped 5 seconds off of pre-push hook for our mid-sized codebase.