### PR TITLE
support pattern in ignoreUnused

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "flow-remove-types": "^2.145.0",
     "glob": "^7.1.6",
     "json5": "^2.2.0",
+    "minimatch": "^3.0.4",
     "ora": "^5.3.0",
     "read-pkg-up": "^7.0.1",
     "resolve": "^1.20.0",

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,6 +1,7 @@
 import { TraverseResult } from './traverse';
 import { Context } from './index';
 import { ensureArray } from './ensureArray';
+import minimatch from 'minimatch';
 
 export interface ProcessedResult {
   unresolved: string[];
@@ -22,7 +23,7 @@ export async function processResults(
   context: Context,
 ): Promise<ProcessedResult> {
   const ignoreUnresolvedIdx = index(context.config.ignoreUnresolved);
-  const ignoreUnusedIdx = index(context.config.ignoreUnused);
+  const ignoreUnused = context.config.ignoreUnused;
   const ignoreUnimportedIdx = index(context.config.ignoreUnimported);
 
   const unresolved = Array.from(traverseResult.unresolved).filter(
@@ -33,7 +34,7 @@ export async function processResults(
     (x) =>
       !traverseResult.modules.has(x) &&
       !context.peerDependencies[x] &&
-      !ignoreUnusedIdx[x],
+      !ignoreUnused.some((ignore) => x == ignore || minimatch(x, ignore)),
   );
 
   const unimported = files

--- a/src/process.ts
+++ b/src/process.ts
@@ -34,7 +34,7 @@ export async function processResults(
     (x) =>
       !traverseResult.modules.has(x) &&
       !context.peerDependencies[x] &&
-      !ignoreUnused.some((ignore) => x == ignore || minimatch(x, ignore)),
+      !ignoreUnused.some((ignore) => x === ignore || minimatch(x, ignore)),
   );
 
   const unimported = files


### PR DESCRIPTION
close #52

Support pattern string for ignoreUnused in .unimportedrc.json like

```
"ignoreUnused": ["@types/*"]
```

using [minimatch](https://github.com/isaacs/minimatch#readme)

