### PR TITLE
feat: add regex path transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ start looking for the aliases from:
 }
 ```
 
+**Path transformations**
+If you wish to transform paths before module resolution, there is an option `pathTransforms` to specify regex search patterns and corresponding replacement values. Search patterns will be applied with the global flag and should **_not_** be enclosed by `/` characters. Replacement values support all special replacement patterns supported by [String.prototype.replaceAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#specifying_a_string_as_a_parameter).
+
+Here is an example for transforming the extension for relative imports from ".js" to ".ts" (this is useful for TypeScript projects configured to output pure ESM).
+
+```json
+{
+  "pathTransforms": {
+    "(\\..+)\\.js$": "$1.ts"
+  }
+}
+```
+
 ## Report
 
 The report will look something like [below](#example). When a particular check didn't have any positive results, it's section will be excluded from the output.

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -795,6 +795,23 @@ export default promise
       exitCode: 0,
       stdout: /There don't seem to be any unimported files./s,
     },
+    {
+      name: 'should evaluate pathTransforms',
+      files: [
+        { name: 'package.json', content: '{ "main": "index.ts" }' },
+        {
+          name: 'index.ts',
+          content: `import { random } from './helpers/index.js';`,
+        },
+        { name: 'helpers/index.ts', content: '' },
+        {
+          name: '.unimportedrc.json',
+          content: '{ "pathTransforms": { "(\\..+)\\.js$": "$1.ts" } }',
+        },
+      ],
+      exitCode: 0,
+      stdout: /There don't seem to be any unimported files./,
+    },
   ],
 );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ export interface UnimportedConfig {
   rootDir?: string;
   extensions?: string[];
   aliases?: MapLike<string[]>;
+  pathTransforms?: MapLike<string>;
 }
 
 type PresetParams = {
@@ -68,6 +69,7 @@ export interface Config {
   moduleDirectory?: string[];
   rootDir?: string;
   extensions: string[];
+  pathTransforms?: MapLike<string>;
 }
 
 export async function expandGlob(
@@ -146,6 +148,7 @@ export async function getConfig(args?: CliArguments): Promise<Config> {
     moduleDirectory: configFile?.moduleDirectory ?? preset?.moduleDirectory,
     entryFiles: [],
     extensions: [],
+    pathTransforms: configFile?.pathTransforms ?? preset?.pathTransforms,
   };
 
   const aliases = configFile?.aliases ?? preset?.aliases ?? {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,7 @@ export async function main(args: CliArguments): Promise<void> {
         moduleDirectory,
         preset: config.preset,
         dependencies,
+        pathTransforms: config.pathTransforms,
       };
 
       // we can't use the third argument here, to keep feeding to traverseResult

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -61,7 +61,7 @@ function transformPath(rawPath: string, config: TraverseConfig): string {
   let path = rawPath;
   if (config.pathTransforms) {
     for (const [search, replace] of Object.entries(config.pathTransforms)) {
-      path = path.replaceAll(new RegExp(search, 'g'), replace);
+      path = path.replace(new RegExp(search, 'g'), replace);
     }
   }
   return path;

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -57,6 +57,16 @@ function getDependencyName(
   return null;
 }
 
+function transformPath(rawPath: string, config: TraverseConfig): string {
+  let path = rawPath;
+  if (config.pathTransforms) {
+    for (const [search, replace] of Object.entries(config.pathTransforms)) {
+      path = path.replaceAll(new RegExp(search, 'g'), replace);
+    }
+  }
+  return path;
+}
+
 export type ResolvedResult =
   | {
       type: 'node_module';
@@ -73,10 +83,11 @@ export type ResolvedResult =
     };
 
 export function resolveImport(
-  path: string,
+  rawPath: string,
   cwd: string,
   config: TraverseConfig,
 ): ResolvedResult {
+  let path = transformPath(rawPath, config);
   const dependencyName = getDependencyName(path, config);
 
   if (dependencyName) {
@@ -308,6 +319,7 @@ export interface TraverseConfig {
   flow?: boolean;
   preset?: string;
   dependencies: MapLike<string>;
+  pathTransforms?: MapLike<string>;
 }
 
 export async function traverse(


### PR DESCRIPTION
This is useful for TypeScript projects outputing pure ESM.

See https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm.

Closes #66.