### PR TITLE
Fix path printing

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -38,7 +38,7 @@ export async function processResults(
 
   const unimported = files
     .filter((x) => !traverseResult.files.has(x))
-    .map((x) => x.substr(context.cwd.length + 1))
+    .map((x) => x.replace(context.cwd + '/', ''))
     .filter((x) => !ignoreUnimportedIdx[x]);
 
   return {


### PR DESCRIPTION
Currently, files from the superdir are cropped in the print output. This PR updates the logic and ensures that we, instead, simply remove `context.cwd + '/'`.