### PR TITLE
fix: local builds with updated dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "debug": "^4.3.2",
     "eslint": "^7.20.0",
     "file-entry-cache": "^6.0.1",
-    "flow-remove-types": "^2.145.0",
+    "flow-remove-types": "2.156.0",
     "glob": "^7.1.6",
     "json5": "^2.2.0",
     "ora": "^5.3.0",

--- a/src/__tests__/help.ts
+++ b/src/__tests__/help.ts
@@ -11,13 +11,13 @@ test('npx unimported --help', async () => {
   // note about `./` path: jest executes the tests from the root directory
   let execResults;
   if (process.platform === 'win32') {
-    // Windows won't understand LC_ALL='en'
+    // Windows won't understand LC_ALL='en_US.utf8'
     execResults = await execAsync(
-      `set LC_All='en' && set NODE_ENV='production' && ts-node src/index.ts --help`,
+      `set LC_All='en-US' && set NODE_ENV='production' && ts-node src/index.ts --help`,
     );
   } else {
     execResults = await execAsync(
-      `LC_ALL='en' NODE_ENV='production' ts-node src/index.ts --help`,
+      `LC_ALL='en_US.utf8' NODE_ENV='production' ts-node src/index.ts --help`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,15 +272,18 @@ export async function main(args: CliArguments): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    const errorWithPath = error as Error & { path?: string };
     // console.log is intercepted for output comparison, this helps debugging
     if (process.env.NODE_ENV === 'test') {
-      console.log(error.message);
+      console.log(errorWithPath.message);
     }
 
     spinner.stop();
     console.error(
       chalk.redBright(
-        error.path ? `\nFailed parsing ${error.path}` : error.message,
+        errorWithPath.path
+          ? `\nFailed parsing ${errorWithPath.path}`
+          : errorWithPath.message,
       ),
     );
     process.exit(1);

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -357,8 +357,9 @@ export async function traverse(
       });
     }
 
-    if (!e.path) {
-      e.path = path;
+    const errorWithPath = e as Error & { path?: string };
+    if (!errorWithPath.path) {
+      errorWithPath.path = path;
     }
     throw e;
   }


### PR DESCRIPTION
I uncovered a few issues when I tried to run the tests locally.

1. TypeScript now treats errors in a catch block as `unknown` which means properties like "message" and "path" cannot be accessed. I've included a workaround to this which doesn't alter the implementation, but a better solution would be to handle instances of specific error classes with a fallback for unanticipated errors.
2. The "en" locale doesn't appear to be valid in any operating system I could find. For me it needed to be "en_US.utf8". From what I could tell searching around it looked like macos uses the same locale and Windows uses "un-US". I've included those changes although it might be useful to actually run the tests on those platforms to make sure it'll work.
3. There was a regression in the `console-testing-library` dependency where a property unimported is using in an options object was removed from their types. I have a PR open to fix it (https://github.com/kevin940726/console-testing-library/pull/26).

A lot of these issues were caused by dependencies introducing breaking changes that were still permitted by the semantic version ranges in the package.json file. You may want to consider committing a `yarn.lock` or `package-lock.json` file to avoid that. Or perhaps pin to exact versions in package.json. Then you can use tools like https://github.com/renovatebot/renovate to stay up-to-date with dependency updates.