### PR TITLE
feat: add support for vue3 setup typescript

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -257,6 +257,14 @@ cases(
             </script>
           `,
         },
+        {
+          name: 'script-setup.vue',
+          content: `
+            <script setup lang="ts">
+              import './script-setup-imported';
+            </script>
+          `,
+        },
         { name: 'script-setup-imported.js', content: '' },
         {
           name: 'script-src.vue',

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -262,7 +262,7 @@ cases(
         {
           name: 'script-setup-ts.vue',
           content: `
-            <script setup>
+            <script setup lang="ts">
               import './script-setup-ts-imported';
             </script>
           `,

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -223,6 +223,7 @@ cases(
             import './script-ts.vue'
             import './script-src.vue'
             import './script-setup.vue';
+            import './script-setup-ts.vue';
           `,
         },
         {
@@ -257,15 +258,16 @@ cases(
             </script>
           `,
         },
+        { name: 'script-setup-imported.js', content: '' },
         {
-          name: 'script-setup.vue',
+          name: 'script-setup-ts.vue',
           content: `
-            <script setup lang="ts">
-              import './script-setup-imported';
+            <script setup>
+              import './script-setup-ts-imported';
             </script>
           `,
         },
-        { name: 'script-setup-imported.js', content: '' },
+        { name: 'script-setup-ts-imported.js', content: '' },
         {
           name: 'script-src.vue',
           content: `            

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -151,7 +151,7 @@ export function resolveImport(
 }
 
 const VueScriptRegExp = new RegExp(
-  '<script(?:(\\s?(?<key>lang|setup|src))(?:=[\'"](?<value>.+)[\'"])?)?\\s?\\/?>',
+  '<script(?:(\\s?(?<key>lang|setup|src))(?:=[\'"](?<value>.+)[\'"])?)*\\s?\\/?>',
   'i',
 );
 


### PR DESCRIPTION
In Vue 3 you can use both typescript and the setup script.

```
<script setup lang="ts">
  import './script-setup-ts-imported';
</script>
```

However the current Vue script tag Regex looks for only ONE of the following "setup|lang|src". To be able to handle the syntax above for Vue 3 setup scripts a minor change to the regex is required. 

This PR makes the regex modification and adds a test to ensure that the syntax above will work.