### PR TITLE
Add Troubleshooting section on TypeScript Declaration Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,16 @@ Please try [clearing the cache](#cache) if you have unexpected results, or keep 
 npx unimported --clear-cache
 ```
 
+### TypeScript declaration files
+
+If you import declaration (`.d.ts`) files in a TypeScript project you will need to add it as an extension to `.unimportedrc.json`. Otherwise you will get "unresolved imports" warnings for imported declaration files.
+
+```json
+{
+  "extensions": [".ts", ".d.ts"]
+}
+```
+
 ## See Also
 
 - [depcheck](https://www.npmjs.com/depcheck)


### PR DESCRIPTION
Following [this comment](https://github.com/smeijer/unimported/issues/62#issuecomment-947985418), this adds a new "Troubleshooting" section about the need to include `.d.ts` in the list of extension when [TypeScript Declaration Files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) are explicitly imported in TypeScript projects.

Happy to update the wording if there's any suggestions :slightly_smiling_face: 

I was also wondering why `.d.ts` wouldn't be included in the list of default extensions, but started with this as it was already suggested in the linked comment.