### PR TITLE
feat: add support for vue3 setup Usage alongside normal script

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -223,7 +223,9 @@ cases(
             import './script-ts.vue'
             import './script-src.vue'
             import './script-setup.vue';
+            import './script-setup-alongside-script.vue';
             import './script-setup-ts.vue';
+            import './script-setup-ts-alongside-script';
           `,
         },
         {
@@ -260,6 +262,19 @@ cases(
         },
         { name: 'script-setup-imported.js', content: '' },
         {
+          name: 'script-setup-alongside-script.vue',
+          content: `
+            <script>
+              import './script-setup-imported';
+            </script>
+            <script setup>
+              import './script-setup2-imported';
+            </script>
+          `,
+        },
+        { name: 'script-setup-imported.js', content: '' },
+        { name: 'script-setup2-imported.js', content: '' },
+        {
           name: 'script-setup-ts.vue',
           content: `
             <script setup lang="ts">
@@ -268,6 +283,20 @@ cases(
           `,
         },
         { name: 'script-setup-ts-imported.js', content: '' },
+        {
+          name: 'script-setup-ts-alongside-script.vue',
+          content: `
+            <script lang="ts">
+              import './script-setup-ts-imported';
+            </script>
+            
+            <script setup lang="ts">
+              import './script-setup-ts2-imported';
+            </script>
+          `,
+        },
+        { name: 'script-setup-ts-imported.js', content: '' },
+        { name: 'script-setup-ts2-imported.js', content: '' },
         {
           name: 'script-src.vue',
           content: `            

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -157,8 +157,8 @@ const VueScriptRegExp = new RegExp(
 
 function extractFromScriptTag(code: string) {
   const lines = code.split('\n');
-  let start = -1;
-  let end = -1;
+  const start: number[] = [];
+  const end: number[] = [];
 
   // walk the code from start to end to find the first <script> tag on it's own line
   for (let idx = 0; idx < lines.length; idx++) {
@@ -171,20 +171,31 @@ function extractFromScriptTag(code: string) {
       return `import '${matches.groups?.value.trim()}';`;
     }
 
-    start = idx;
-    break;
+    start.push(idx);
+
+    if (start.length === 2) {
+      break;
+    }
   }
 
   // walk the code in reverse to find the last </script> tag on it's own line
   for (let idx = lines.length - 1; idx >= 0; idx--) {
     if (lines[idx].trim() === '</script>') {
-      end = idx;
+      end.push(idx);
+    }
+    if (end.length === 2) {
       break;
     }
   }
 
-  const str =
-    start > -1 && end > -1 ? lines.slice(start + 1, end).join('\n') : '';
+  let str = '';
+
+  if (start.length > 0 && end.length > 0) {
+    const endReversed = end.reverse();
+    start.forEach((value, index) => {
+      str += lines.slice(value + 1, endReversed[index]).join('\n');
+    });
+  }
 
   return str;
 }


### PR DESCRIPTION
In vue 3 it's possible to have two script import in one file see:

https://vuejs.org/api/sfc-script-setup.html#usage-alongside-normal-script

To be able to parse this kind of file the extractFromScriptTag function must be changed.

This PR try to solve this problem 

@smeijer 