### PR TITLE
feat: support template literals in require()s

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -436,7 +436,7 @@ import bar from './bar';
       stdout: /There don't seem to be any unimported files/,
     },
     {
-      name: 'should use all variants of import/export',
+      name: 'should use all variants of import/export/require',
       files: [
         {
           name: 'package.json',
@@ -452,6 +452,12 @@ import bar from './bar';
 import {b as a} from './b'
 const promise = import('./d')
 const templatePromise = import(\`./e\`)
+const promiseAwaited = await import('./f')
+const templatePromiseAwaited = await import(\`./g\`)
+const required = require('./h')
+const templateRequired = require(\`./i\`)
+const requiredAwaited = await require('./j')
+const templateRequiredAwaited = await require(\`./k\`)
 export {a}
 export {b} from './b'
 export * from './c'
@@ -462,6 +468,12 @@ export default promise
         { name: 'c.js', content: 'const c = 3; export {c}' },
         { name: 'd.js', content: 'export default 42' },
         { name: 'e.js', content: 'export default 42' },
+        { name: 'f.js', content: 'export default 42' },
+        { name: 'g.js', content: 'export default 42' },
+        { name: 'h.js', content: 'export default 42' },
+        { name: 'i.js', content: 'export default 42' },
+        { name: 'j.js', content: 'export default 42' },
+        { name: 'k.js', content: 'export default 42' },
       ],
       exitCode: 0,
       stdout: /There don't seem to be any unimported files./,

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -301,7 +301,19 @@ async function parse(path: string, config: TraverseConfig): Promise<FileStats> {
             break;
           }
 
-          target = (node.arguments[0] as Literal).value;
+          const [argument] = node.arguments;
+
+          if (argument.type === 'TemplateLiteral') {
+            // Allow for constant template literals, require(`.x`)
+            if (
+              argument.expressions.length === 0 &&
+              argument.quasis.length === 1
+            ) {
+              target = argument.quasis[0].value.cooked;
+            }
+          } else {
+            target = (argument as Literal).value;
+          }
           break;
         }
       }


### PR DESCRIPTION
Hiya :wave:

The project previously added support for ```import(`template-literal`)```, but not for ```require(`template-literal`)``` (https://github.com/smeijer/unimported/pull/29).

This PR extracts the existing logic for `import()` to a function, and uses it to add support within `require()` statements. It also handles "weird" cases like `require()` (empty) or `require(...something)` (spreads)...because it makes TypeScript less complainy 💅

I added some tests for `await`'d `import`s too, just for completeness, as they were referenced in the `traverse.ts` comments.