### PR TITLE
feat: added format flags for unused, unimported and unresolved to print them separately

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -44,6 +44,9 @@ async function exec(
     cache = true,
     clearCache = false,
     showConfig = false,
+    showUnresolvedImports = false,
+    showUnusedFiles = false,
+    showUnusedDeps = false,
   }: Partial<CliArguments> = {},
 ): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
   const originalExit = process.exit;
@@ -86,6 +89,9 @@ async function exec(
       cache,
       clearCache,
       showConfig,
+      showUnresolvedImports,
+      showUnusedFiles,
+      showUnusedDeps,
     });
 
     return { exitCode: exitCode ?? 0, stdout, stderr };

--- a/src/__tests__/help.ts
+++ b/src/__tests__/help.ts
@@ -24,7 +24,7 @@ test('npx unimported --help', async () => {
   const { stdout, stderr } = execResults;
 
   expect(stderr).toBe('');
-  console.log(stdout.trim());
+
   expect(stdout.trim()).toMatchInlineSnapshot(`
   "unimported [cwd]
 

--- a/src/__tests__/help.ts
+++ b/src/__tests__/help.ts
@@ -24,29 +24,37 @@ test('npx unimported --help', async () => {
   const { stdout, stderr } = execResults;
 
   expect(stderr).toBe('');
+  console.log(stdout.trim());
   expect(stdout.trim()).toMatchInlineSnapshot(`
-    "unimported [cwd]
+  "unimported [cwd]
 
-    scan your project for dead files
-
-    Positionals:
-      cwd  The root directory that unimported should run from.              [string]
-
-    Options:
-          --version           Show version number                          [boolean]
-          --help              Show help                                    [boolean]
-          --cache             Whether to use the cache. Disable the cache using
-                              --no-cache.                  [boolean] [default: true]
-          --clear-cache       Clears the cache file and then exits.        [boolean]
-      -f, --flow              Whether to strip flow types, regardless of @flow
-                              pragma.                                      [boolean]
-          --ignore-untracked  Ignore files that are not currently tracked by git.
-                                                                           [boolean]
-      -i, --init              Dump default settings to .unimportedrc.json. [boolean]
-          --show-config       Show config and then exists.                 [boolean]
-          --show-preset       Show preset and then exists.                  [string]
-      -u, --update            Update the ignore-lists stored in .unimportedrc.json.
-                                                                           [boolean]
-          --config            The path to the config file.                  [string]"
-  `);
+  scan your project for dead files
+  
+  Positionals:
+    cwd  The root directory that unimported should run from.              [string]
+  
+  Options:
+        --version                  Show version number                   [boolean]
+        --help                     Show help                             [boolean]
+        --cache                    Whether to use the cache. Disable the cache
+                                   using --no-cache.     [boolean] [default: true]
+        --clear-cache              Clears the cache file and then exits. [boolean]
+    -f, --flow                     Whether to strip flow types, regardless of
+                                   @flow pragma.                         [boolean]
+        --ignore-untracked         Ignore files that are not currently tracked by
+                                   git.                                  [boolean]
+    -i, --init                     Dump default settings to .unimportedrc.json.
+                                                                         [boolean]
+        --show-config              Show config and then exists.          [boolean]
+        --show-preset              Show preset and then exists.           [string]
+    -u, --update                   Update the ignore-lists stored in
+                                   .unimportedrc.json.                   [boolean]
+        --config                   The path to the config file.           [string]
+        --show-unused-files        formats and only prints unimported files
+                                                                         [boolean]
+        --show-unused-deps         formats and only prints unused dependencies
+                                                                         [boolean]
+        --show-unresolved-imports  formats and only prints unresolved imports
+                                                                         [boolean]"
+`);
 });

--- a/src/__tests__/print.ts
+++ b/src/__tests__/print.ts
@@ -17,6 +17,9 @@ describe('printResults', () => {
       ignoreUnused: [],
       ignoreUnresolved: [],
     },
+    showUnresolvedImports: false,
+    showUnusedDeps: false,
+    showUnusedFiles: false,
   } as Context;
 
   let restore: any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,9 @@ export interface Context {
   config: Config;
   moduleDirectory: string[];
   cacheId?: string;
+  showUnusedFiles: boolean;
+  showUnusedDeps: boolean;
+  showUnresolvedImports: boolean;
 }
 
 const oraStub = {
@@ -304,6 +307,9 @@ export interface CliArguments {
   showConfig: boolean;
   showPreset?: string;
   config?: string;
+  showUnusedFiles: boolean;
+  showUnusedDeps: boolean;
+  showUnresolvedImports: boolean;
 }
 
 if (process.env.NODE_ENV !== 'test') {
@@ -368,6 +374,21 @@ if (process.env.NODE_ENV !== 'test') {
         yargs.option('config', {
           type: 'string',
           describe: 'The path to the config file.',
+        });
+
+        yargs.option('show-unused-files', {
+          type: 'boolean',
+          describe: 'formats and only prints unimported files',
+        });
+
+        yargs.option('show-unused-deps', {
+          type: 'boolean',
+          describe: 'formats and only prints unused dependencies',
+        });
+
+        yargs.option('show-unresolved-imports', {
+          type: 'boolean',
+          describe: 'formats and only prints unresolved imports',
         });
       },
       function (argv: Arguments<CliArguments>) {

--- a/src/print.ts
+++ b/src/print.ts
@@ -68,6 +68,7 @@ export function printResults(result: ProcessedResult, context: Context): void {
     return;
   }
 
+  const { showUnresolved, showUnused, showUnimported } = chooseResults(context);
   const { unresolved, unused, unimported } = result;
 
   // render
@@ -79,7 +80,7 @@ export function printResults(result: ProcessedResult, context: Context): void {
     ),
   );
 
-  if (unresolved.length > 0) {
+  if (showUnresolved && unresolved.length > 0) {
     console.log(
       formatList(
         chalk.redBright(`${unresolved.length} unresolved imports`),
@@ -88,7 +89,7 @@ export function printResults(result: ProcessedResult, context: Context): void {
     );
   }
 
-  if (unused.length > 0) {
+  if (showUnused && unused.length > 0) {
     console.log(
       formatList(
         chalk.blueBright(`${unused.length} unused dependencies`),
@@ -97,7 +98,7 @@ export function printResults(result: ProcessedResult, context: Context): void {
     );
   }
 
-  if (unimported.length > 0) {
+  if (showUnimported && unimported.length > 0) {
     console.log(
       formatList(
         chalk.cyanBright(`${unimported.length} unimported files`),
@@ -111,4 +112,24 @@ export function printResults(result: ProcessedResult, context: Context): void {
       'npx unimported -u',
     )} to update ignore lists`,
   );
+}
+
+function chooseResults(context: Context) {
+  const { showUnresolvedImports, showUnusedDeps, showUnusedFiles } = context;
+  const showAllResults =
+    // when all three flags are used
+    (showUnresolvedImports && showUnusedDeps && showUnusedFiles) ||
+    // when none flag is used
+    (!showUnresolvedImports && !showUnusedDeps && !showUnusedFiles);
+
+  const showUnresolved = showUnresolvedImports || showAllResults;
+  const showUnused = showUnusedDeps || showAllResults;
+  const showUnimported = showUnusedFiles || showAllResults;
+
+  return {
+    showAllResults,
+    showUnresolved,
+    showUnused,
+    showUnimported,
+  };
 }


### PR DESCRIPTION
This PR is created for the issue: https://github.com/smeijer/unimported/issues/106

It adds the following flags:
--show-unused-files
--show-unused-deps
--show-unresolved-imports

To print their outputs separately.

If no flag is passed then all output is shown by default