### PR TITLE
feat: allow to config ignore entries

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ export interface UnimportedConfig {
     | string
     | {
         file: string;
+        ignore?: string | string[];
         label?: string;
         aliases?: MapLike<string[]>;
         extensions?: string[];
@@ -76,12 +77,16 @@ export interface Config {
 
 export async function expandGlob(
   patterns: string | string[],
+  options?: {
+    ignore?: string | string[];
+  },
 ): Promise<string[]> {
   const set = new Set<string>();
 
   for (const pattern of ensureArray(patterns)) {
     const paths = await globAsync(pattern, {
       realpath: false,
+      ignore: options?.ignore,
     });
 
     for (const path of paths) {
@@ -192,7 +197,9 @@ export async function getConfig(args?: CliArguments): Promise<Config> {
         ? [...entry.extend.extensions, ...extensions]
         : extensions;
 
-      for (const file of await expandGlob(entry.file)) {
+      for (const file of await expandGlob(entry.file, {
+        ignore: entry.ignore,
+      })) {
         config.entryFiles.push({
           file,
           label: entry.label,


### PR DESCRIPTION
Closes https://github.com/smeijer/unimported/issues/108

Allow to config ignore in entry config. Then it will be passed to the glob options.
```
{
  "entry": [
    {
      "file": "pages/**/*.tsx",
      "ignore": ["**/_*", "**/_*/**"]
    }
  ]
}
```