### PR TITLE
feat: Specify cwd to read tsconfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,7 @@ export async function main(args: CliArguments): Promise<void> {
         extensions: entry.extensions,
         assetExtensions: config.assetExtensions,
         // resolve full path of aliases
-        aliases: await meta.getAliases(entry),
+        aliases: await meta.getAliases(entry, args.cwd ?? cwd),
         cacheId: args.cache ? getCacheIdentity(entry) : undefined,
         flow: config.flow,
         moduleDirectory,

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,8 @@ export async function main(args: CliArguments): Promise<void> {
 
     // traverse the file system and get system data
     spinner.text = 'traverse the file system';
-    const baseUrl = (await fs.exists('src', cwd)) ? join(cwd, 'src') : cwd;
+    const parent = args.cwd ?? cwd;
+    const baseUrl = (await fs.exists('src', parent)) ? join(parent, 'src') : parent;
     const files = await fs.list('**/*', baseUrl, {
       extensions: [...config.extensions, ...config.assetExtensions],
       ignore: config.ignorePatterns,

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -30,9 +30,9 @@ export function typedBoolean<T>(
   return Boolean(value);
 }
 
-export const readTsconfig = () => {
+export const readTsconfig = (cwd: string) => {
   const resolvedPathname = findConfigFile(
-    process.cwd(),
+    cwd,
     sys.fileExists,
     'tsconfig.json',
   );
@@ -47,7 +47,7 @@ export const readTsconfig = () => {
     return undefined;
   }
 
-  const { options } = parseJsonConfigFileContent(config, sys, process.cwd());
+  const { options } = parseJsonConfigFileContent(config, sys, cwd);
 
   return {
     compilerOptions: options,
@@ -56,13 +56,14 @@ export const readTsconfig = () => {
 
 export async function getAliases(
   entryFile: EntryConfig,
+  cwd: string,
 ): Promise<MapLike<string[]>> {
   const [packageJson, jsconfig] = await Promise.all([
-    fs.readJson<PackageJson>('package.json'),
-    fs.readJson<JsConfig>('jsconfig.json'),
+    fs.readJson<PackageJson>('package.json', cwd),
+    fs.readJson<JsConfig>('jsconfig.json', cwd),
   ]);
 
-  const tsconfig = readTsconfig();
+  const tsconfig = readTsconfig(cwd);
   const config = await getConfig();
 
   let aliases: Aliases = {};


### PR DESCRIPTION
Considering [NX integrated monorepo](https://nx.dev/getting-started/tutorials/integrated-repo-tutorial), each app has its own tsconfig.json file. Also, a tsconfig.json also could be located at the root dir.

Currently, this project always read cwd from `process.cwd()` which is the root dir, which leads to reading the wrong tsconfig file. 

This pull request changes the code to allow specifiying a `cwd` argument to the `readTsconfig` function. The `cwd` comes from the `getAliases` `cwd` argument.