### PR TITLE
feat: Add Expo Support for React Native Preset

### DIFF
--- a/src/presets/react-native.ts
+++ b/src/presets/react-native.ts
@@ -24,6 +24,27 @@ function getEntry(target: string, rootExtensions: string[]) {
     },
   };
 }
+
+function getExpo(options, rootExtensions: string[]) {
+  const expoEntry = options.packageJson.main;
+
+  if (!expoEntry) {
+    return;
+  }
+
+  const [file] = resolveFilesSync([expoEntry], rootExtensions);
+
+  if (!file) {
+    return;
+  }
+  return {
+    file,
+    label: 'expo',
+    extend: {
+      extensions: rootExtensions,
+    },
+  };
+}
 const preset: Preset = {
   name: 'react-native',
   isMatch: ({ hasPackage }) => hasPackage('react-native'),
@@ -31,9 +52,12 @@ const preset: Preset = {
     const base = await nodePreset.getConfig(options);
     const extensions = base.extensions as string[];
 
+    const hasExpo = options.hasPackage('expo');
+
     const entry = [
       getEntry('android', extensions),
       getEntry('ios', extensions),
+      hasExpo ? getExpo(options, extensions) : undefined,
     ].filter(typedBoolean);
 
     return {


### PR DESCRIPTION
#### Changes Made

This pull request introduces support for Expo in the React Native preset. Expo projects typically utilize the `main` key in `package.json` as their entry point, linking to `AppEntry.js`.

#### Purpose

The addition of Expo support ensures that unimported will seamlessly integrate with Expo out of the box. This enhancement is crucial for Expo React Native projects, providing a smoother development experience.

Please review the changes and provide any feedback or suggestions. Your input is greatly appreciated.

Thank you!
