### PR TITLE
fix: `ignoreUnresolved`

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -839,7 +839,7 @@ export default promise
         { name: 'index.js', content: `import foo from './foo';` },
         {
           name: '.unimportedrc.json',
-          content: '{"ignoreUnresolved": ["./foo"]}',
+          content: '{"ignoreUnresolved": [["./foo", ["index.js"]]]}',
         },
       ],
       exitCode: 0,

--- a/src/process.ts
+++ b/src/process.ts
@@ -34,7 +34,7 @@ export async function processResults(
   const ignoreUnimportedIdx = index(context.config.ignoreUnimported);
 
   const unresolved = Array.from(traverseResult.unresolved).filter(
-    ([x]) => !ignoreUnresolvedIdx[x],
+    (entry) => !ignoreUnresolvedIdx[entry.toString()],
   );
 
   const unused = Object.keys(context.dependencies).filter(


### PR DESCRIPTION
Fixes #190 by using the `unresolved` entry's `toString` (rather than its first part) to check for its presence inside the `ignoreUnresolved` index.