### PR TITLE
FIX: try to resolve file path from root alias - Help needed

### DIFF
--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -150,6 +150,23 @@ export function resolveImport(
     };
   } catch (e) {}
 
+   // Try to resolve the path relative to the root
+   for (const rootAlias of config.aliases["/"]) {
+    try {
+        return {
+            type: 'source_file',
+            path: resolve
+                .sync(`${rootAlias}/${path}`, {
+                    basedir: cwd,
+                    extensions: config.extensions,
+                    moduleDirectory: config.moduleDirectory,
+                })
+                .replace(/\\/g, '/'),
+        };
+    }
+    catch (e) { }
+  }
+
   // if nothing else works out :(
   return {
     type: 'unresolved',


### PR DESCRIPTION
Disclaimer:

I have no idea on overall how this function is even working, nor why It happens to meAll I know is that sometimes the resolveImport method is called with this for example:

path: /src/core/schedules/dto/schedule-schema/schedule-composition-data.dto
cdw: /Users/nathangouy/Work/backend/src/actions/account-managment/some-action

and it fails to resolve

I also have seen that in my aliases, I had an alias for the root that points to `/Users/nathangouy/Work/backend/`
So plugging the "root" alias  with the path makes my trouble go away

-----
TODO:
- [ ] tests (no idea how to test)

-----
PS: my config is as simple as it can gets:

```json
{
  "entry": [
    "src/app.module.ts",
    "src/main.ts"
  ],
  "extensions": [
    ".ts",
    ".js"
  ]
}
```